### PR TITLE
fpm binary not found on Debianoids if installed via gem_package

### DIFF
--- a/libraries/fpm_tng.rb
+++ b/libraries/fpm_tng.rb
@@ -1,4 +1,8 @@
+require 'chef/mixin/shell_out'
+
 module FpmTng
+  extend Chef::Mixin::ShellOut
+
   STRINGS = %w(
     prefix license vendor category architecture maintainer
     package_name_suffix description url inputs before_install
@@ -21,4 +25,14 @@ module FpmTng
     deb_ignore_iteration_in_dependencies python_fix_name
     python_fix_dependencies pear_channel_update auto_depends
   )
+
+  def self.fpm_exec_path(node)
+    bindir = gem_bindir(node)
+    bindir.empty? ? 'fpm' : File.join(bindir, 'fpm')
+  end
+
+  def self.gem_bindir(node)
+    cmd = 'require "rubygems"; puts Gem.default_bindir'
+    shell_out(node[:languages][:ruby][:ruby_bin], '-e', cmd).stdout.chomp
+  end
 end

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -1,11 +1,11 @@
-node.default[:fpm_tng][:exec] = File.join(node[:languages][:ruby][:bin_dir], 'fpm')
+node.default[:fpm_tng][:exec] = FpmTng.fpm_exec_path(node)
 node.default[:fpm_tng][:gem] = node[:languages][:ruby][:gem_bin]
 
 begin
   resources(:ohai => 'ruby')
   ruby_block 'Reset ruby defaults' do
     block do
-      node.default[:fpm_tng][:exec] = File.join(node[:languages][:ruby][:bin_dir], 'fpm')
+      node.default[:fpm_tng][:exec] = FpmTng.fpm_exec_path(node)
       node.default[:fpm_tng][:gem] = File.join(node[:languages][:ruby][:bin_dir], 'gem')
     end
     action :nothing


### PR DESCRIPTION
System ruby packages on Debian based systems put ruby and gem binaries in `/usr/bin/` and thus Ohai will set `node['languages']['ruby']['bin_dir']` to it. But system rubygem installs its binaries by default to either `$(gem env gemdir)/bin/` or `/usr/local/bin/` (depending on the distro and version).
So `node['fpm_tng']['exec']` pointing to `/usr/bin/fpm` is most probably wrong in these cases.

I'm not even sure what would be the best fox for this. Obviously the ruby is not necessarily even installed from the distro package.

Any thoughts?
