### PR TITLE
'Reset ruby defaults' ruby_block cannot be notified early enough

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -1,16 +1,5 @@
-begin
-  resources(:ohai => 'ruby')
-  ruby_block 'Reset ruby defaults' do
-    block do
-      node.default[:fpm_tng][:exec] = File.join(node.languages.ruby.bin_dir, 'fpm')
-      node.default[:fpm_tng][:gem] = File.join(node.languages.ruby.bin_dir, 'gem')
-    end
-    action :nothing
-    subscribes :create, 'ohai[ruby]', :immediately
-  end
-rescue Chef::Exceptions::ResourceNotFound
-  Chef::Log.warn 'No ohai ruby reload found.'
-end
+node.default[:fpm_tng][:exec] = File.join(node.languages.ruby.bin_dir, 'fpm')
+node.default[:fpm_tng][:gem] = node.languages.ruby.gem_bin
 
 unless(node[:fpm_tng][:bundle][:enable])
   node[:fpm_tng][:install][:gems].each do |fpm_gem|


### PR DESCRIPTION
If I want to install a new ruby interpreter to be used with this cookbook, I fail to see how can I notify the 'Reset ruby defaults' ruby_block in time to have effect when installing the bundler or fpm gems.

The problem is that Ohai and thus the default `node[:fpm_tng][:exec]` and `[:gem]` attributes have the situation before the new ruby is installed. On my default system the only ruby is the one from the Omnibus. I can install the ruby and reload Ohai data at compile time, but the default attributes are anyway already set.

If I reload Ohai before including the `fpm-tng::default` recipe, the 'Reset ruby defaults' resource is not yet created and won't be evaluated. If I include the default recipe earlier, it already creates all the `gem_package` resources with the original gem_binary. Changing the node attributes won't change the resources even if they are only executed at converge phase. 

What about just setting `node.default[:fpm_tng][:exec]` and `[:gem]` unconditionally in the recipe? This way they would always be evaluated at compile time. Then the user is responsible of up-to-date Ohai data before loading the recipe. Or the user can use normal or override attributes to force them.
