### PR TITLE
Allow `iteration` attribute to be a string

### DIFF
--- a/libraries/fpm_tng.rb
+++ b/libraries/fpm_tng.rb
@@ -9,9 +9,9 @@ module FpmTng
     rpm_digest rpm_compression rpm_os rpm_changelog python_bin
     python_easyinstall python_pip python_pypi python_package_name_prefix
     python_install_bin python_install_lib python_install_data
-    pear_package_name_prefix pear_channel version package
+    pear_package_name_prefix pear_channel version iteration package
   )
-  NUMERICS = %w(iteration epoch)
+  NUMERICS = %w(epoch)
   STRING_ARRAYS = %w(
     depends provides conflicts replaces config_files directories exclude
     template_value deb_pre_depends


### PR DESCRIPTION
At least with Debianoids the iteration (or revision) can include alphabetical and even some special characters. For example backported packages often use a formats like `-1~bpo60+1`.

fpm just uses `iteration.to_s` so it doesn't care ([code](https://github.com/jordansissel/fpm/blob/v0.4.36/lib/fpm/package.rb#L328-L339)).
